### PR TITLE
Add network timezones validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: 10.1.0
+node_js: 10.9.0
 cache:
   yarn: true
 script:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "glob": "^7.1.2",
     "json-dup-key-validator": "^1.0.2",
     "jsonschema": "^1.2.4",
+    "moment-timezone": "^0.5.21",
     "winston": "^3.0.0",
     "xo": "^0.21.1"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "glob": "^7.1.2",
     "json-dup-key-validator": "^1.0.2",
     "jsonschema": "^1.2.4",
+    "lodash": "^4.17.10",
     "moment-timezone": "^0.5.21",
     "winston": "^3.0.0",
     "xo": "^0.21.1"

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -442,7 +442,7 @@ Canal de las Estrellas Latinoamerica (US):US/Eastern
 Canal de las Estrellas:America/Mexico_City
 Canal+ (ES):Europe/Madrid
 Canal+ (FR):Europe/Paris
-Canal+ Cyfrowy:Poland/Warsaw
+Canal+ Cyfrowy:Europe/Warsaw
 Canal+:Europe/Paris
 Canale 5:Europe/Rome
 Cancao News (US):US/Eastern
@@ -1232,7 +1232,7 @@ Movie Central:Canada/Eastern
 Movie Extra (AU):Australia/Sydney
 Movies 24 (UK):Europe/London
 Movies4Men (UK):Europe/London
-Movistar+:Europe/Spain
+Movistar+:Europe/Madrid
 Much (CA):Canada/Eastern
 Much TV:Asia/Taipei
 MuchMusic (CA):Canada/Eastern

--- a/validate.js
+++ b/validate.js
@@ -6,7 +6,7 @@ const path = require('path');
 const glob = require('glob');
 const winston = require('winston');
 const { Validator } = require('jsonschema');
-const jsonHandler = require('json-dup-key-validator');
+const dupKeyValidator = require('json-dup-key-validator');
 
 const log = winston.createLogger({
   transports: [new winston.transports.Console()],
@@ -24,9 +24,9 @@ const log = winston.createLogger({
  * @returns {(string|null)} Error if failed, null if passed
  */
 const validateJSON = (filePath, validator) => {
-  const data = fs.readFileSync(filePath, 'utf8');
+  const data = fs.readFileSync(filePath, 'utf-8');
 
-  const isInvalid = jsonHandler.validate(data, false);
+  const isInvalid = dupKeyValidator.validate(data, false);
   if (isInvalid !== undefined) {
     return isInvalid.replace(/\n/g, '\\n');
   }
@@ -107,8 +107,9 @@ const validateSceneExceptions = () => {
  * @returns {boolean} Validation result.
  */
 const validateBrokenProviders = () => {
-  const filePath = path.join(__dirname, 'providers', 'broken_providers.json');
-  log.info(`Validating: providers/broken_providers.json`);
+  const relFile = 'providers/broken_providers.json';
+  const filePath = path.resolve(__dirname, relFile);
+  log.info(`Validating: ${relFile}`);
 
   const validator = new Validator();
   validator.addSchema({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,16 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment-timezone@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.21.tgz#3cba247d84492174dbf71de2a9848fa13207b845"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
- [x] Update previous code.
- [x] Add network timezones validation, which makes sure:
	- [x] There's one (and only one) empty line at the end of the file.
	- [x] There are no empty lines in the file (apart from the last one).
	- [x] File is using Linux EOL chars (`\n`).
	- [x] Each line matches the format: `Network Name:Timezone` (exact match - no whitespaces).
	- [x] The timezones used are valid.
	- [x] The list is ordered.
- [x] Update Node.js to `v10.9.0`.
- [x] Fix invalid timezones in `network_timezones.txt`.