### PR TITLE
Add Missing time zone for network: Crime & Investigation Network (UK)

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -552,6 +552,7 @@ CraveTV:Canada/Eastern
 Create and Craft (UK):Europe/London
 Credo TV (US):US/Eastern
 Crime & Investigation Network (AU):Australia/Sydney
+Crime & Investigation Network (UK):Europe/London
 Crime & Investigation Network:US/Eastern
 Crunchyroll:US/Pacific
 Cuatro:Europe/Madrid


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/6417