### PR TITLE
Add Missing time zone for network: ITV Hub

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1005,6 +1005,7 @@ ITV 1:Europe/London
 ITV Encore:Europe/London
 ITV Gold (US):US/Eastern
 ITV Granada:Europe/London
+ITV Hub:Europe/London
 ITV Wales:Europe/London
 ITV1:Europe/London
 ITV2:Europe/London


### PR DESCRIPTION
> 2019-05-06 19:32:22 ERROR    Thread_7 :: [f46bfac] Missing time zone for network: ITV Hub