### PR TITLE
Add Missing time zone for network: NOVA

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1348,6 +1348,7 @@ NHNZ:Pacific/Auckland
 NITV (AU):Australia/Sydney
 NJPW World:Asia/Tokyo
 NOS:Europe/Amsterdam
+NOVA:Europe/Sofia
 NPO 1:Europe/Amsterdam
 NPO 2:Europe/Amsterdam
 NPO 3:Europe/Amsterdam

--- a/scene_exceptions/scene_exceptions_tmdb.json
+++ b/scene_exceptions/scene_exceptions_tmdb.json
@@ -121,7 +121,8 @@
         },
         "71446": {
             "-1": [
-                "La Casa de Papel"
+                "La Casa de Papel",
+                "Money Heist"
             ]
         },
         "78578": {
@@ -199,12 +200,6 @@
         "61068": {
             "-1": [
                 "Gomorra"
-            ]
-        },
-        "71446": {
-            "-1": [
-                "La casa de papel",
-                "Money Heist"
             ]
         }
     }


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/6989

Also fix:
>[07:18:55] info: Validating: scene_exceptions/scene_exceptions_tmdb.json
[07:18:55] error: Syntax error: duplicated keys "71446" near 1446": {\n 
[07:18:55] info: Validating: scene_exceptions/scene_exceptions_tvdb.json
