### PR TITLE
Add Missing time zone for network: BET+

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -265,6 +265,7 @@ BCV (AU):Australia/Sydney
 BET (UK):Europe/London
 BET Gospel (US):US/Eastern
 BET HIP HOP (US):US/Eastern
+BET+:US/Eastern
 BET:US/Eastern
 BHSN (US):US/Eastern
 BIOGRAPHY CHANNEL (CA):Canada/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/7176