### PR TITLE
Add Missing time zone for networks: CTV Sci-Fi Channel & Virgin 1

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -428,6 +428,7 @@ CTS:Asia/Tokyo
 CTV (CN):Asia/Shanghai
 CTV (JP):Asia/Tokyo
 CTV News Channel (CA):Canada/Eastern
+CTV Sci-Fi Channel:Canada/Eastern
 CTV Television Network:Canada/Eastern
 CTV two (CA):Canada/Eastern
 CTV:Canada/Eastern
@@ -2348,6 +2349,7 @@ Videoland Television Network:Asia/Taipei
 VijfTV:Europe/Brussels
 Vimeo:US/Eastern
 Vintage TV (UK):Europe/London
+Virgin 1:Europe/London
 Vision (UK):Europe/London
 Vision 2 (UK):Europe/London
 Vision Heaven (US):US/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/7188

https://en.wikipedia.org/wiki/Channel_One_(UK_and_Ireland)  
Formerly called  Virgin1
