### PR TITLE
Add Missing time zone for network: FOX+

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -816,6 +816,7 @@ FOX Sports 1:US/Eastern
 FOX Sports 2:US/Eastern
 FOX Traveller:Asia/Kolkata
 FOX Türkiye:Europe/Istanbul
+FOX+:US/Eastern
 FOX:US/Eastern
 FRANCE24 (US):US/Eastern
 FSN:US/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/7620