### PR TITLE
Add Missing time zone for network: La Uno (TVE1)

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1177,6 +1177,7 @@ La Red:Europe/Madrid
 La Siete:Europe/Madrid
 La Trois:Europe/Brussels
 La Une:Europe/Brussels
+La Uno (TVE1):Europe/Madrid
 La7:Europe/Rome
 LaSexta:Europe/Rome
 Latest TV (UK):Europe/London


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/8192