### PR TITLE
Add Missing time zone for network: HBO España

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -977,6 +977,7 @@ HBO Asia:Asia/Singapore
 HBO Brasil:America/Sao_Paulo
 HBO CANADA:Canada/Eastern
 HBO Canada:Canada/Eastern
+HBO España:Europe/Madrid
 HBO Europe:Europe/Budapest
 HBO Family (US):US/Eastern
 HBO Go:US/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/8381