### PR TITLE
Update network_timezones.txt

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -288,6 +288,7 @@ BKN (AU):Australia/Sydney
 BLISS (UK):Europe/London
 BNN (NL):Europe/Amsterdam
 BNN-VARA:Europe/Amsterdam
+BNNVARA:Europe/Amsterdam
 BNN:Canada/Eastern
 BNT1:Europe/Sofia
 BOS (NL):Europe/Amsterdam


### PR DESCRIPTION
Added alternative name for Dutch BNNVARA network. The network is already present as BNN-VARA, but the hyphen is no longer used (https://www.bnnvara.nl/). Since the hyphened version has been used before, it should remain in.