### PR TITLE
Add Add Missing time zone for networks: RTS1,  Prva Srpska Televizija

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1721,6 +1721,7 @@ RTQ (AU):Australia/Sydney
 RTS (AU):Australia/Sydney
 RTS Deux:Europe/Zurich
 RTS Un:Europe/Zurich
+RTS1:Europe/Belgrade
 RTV Noord (NL):Europe/Amsterdam
 RTV Noord-Holland (NL):Europe/Amsterdam
 RTV Oost (NL):Europe/Amsterdam

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1641,6 +1641,7 @@ Primetime (UK):Europe/London
 ProSieben Fun:Europe/Berlin
 ProSieben MAXX:Europe/Berlin
 ProSieben:Europe/Berlin
+Prva Srpska Televizija:Europe/Belgrade
 Psychic Today (UK):Europe/London
 Pub Channel:Europe/London
 Public Broadcasting Service:US/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/8729  
fix https://github.com/pymedusa/Medusa/issues/8730  