### PR TITLE
Add Gunma TV

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -990,6 +990,7 @@ Great American Country:US/Eastern
 Greatest Hits (UK):Europe/London
 Guardian Television Network:US/Eastern
 Gulli:Europe/Paris
+Gunma TV:Asia/Tokyo
 H2 (CA):Canada/Eastern
 H2 (UK):Europe/London
 H2:US/Eastern


### PR DESCRIPTION
Gunma TV is one of the networks distributing Vivy -Fluorite Eye's Song-

https://www.themoviedb.org/tv/116725