### PR TITLE
Add Missing time zone for network: RAI 1

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1709,6 +1709,7 @@ QVC:US/Eastern
 Quest Red:Europe/London
 Quest:Europe/London
 Quibi:US/Pacific
+RAI 1:Europe/Rome
 RAI:Europe/Rome
 RBB:Europe/Berlin
 RCN TV:America/Bogota


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/5628