### PR TITLE
Add Missing time zone for network: Nitro

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1548,6 +1548,7 @@ Nine Network:Australia/Sydney
 Nippon Housou Kyoukai:Asia/Tokyo
 Nippon TV:Asia/Tokyo
 Nippon Television:Asia/Tokyo
+Nitro:Europe/Berlin
 Noggin:US/Eastern
 Nolife:Europe/Paris
 Nollywood Movies (UK):Europe/London

--- a/scene_exceptions/scene_exceptions_tmdb.json
+++ b/scene_exceptions/scene_exceptions_tmdb.json
@@ -236,7 +236,7 @@
                 "The Queens Gambit"
             ]
         },
-        "87739": {
+        "128500": {
             "-1": [
                 "Myth and Mogul John DeLorean"
             ]


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/9878