### PR TITLE
Add Missing time zone for network: HGTV (UK)

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1030,6 +1030,7 @@ HBO Česká Republika:Europe/Prague
 HBO2 (US):US/Eastern
 HBO:US/Eastern
 HDNet:US/Eastern
+HGTV (UK):Europe/London
 HGTV Canada:Canada/Eastern
 HGTV:US/Eastern
 HIFI:Canada/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10163