### PR TITLE
Add Missing time zone for network: Prime Video

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1707,6 +1707,7 @@ Prima Family (CZ):Europe/Prague
 Prima televize:Europe/Prague
 Prime (BE):Europe/Brussels
 Prime (NZ):Pacific/Auckland
+Prime Video:US/Eastern
 Primetime (UK):Europe/London
 ProSieben Fun:Europe/Berlin
 ProSieben MAXX:Europe/Berlin


### PR DESCRIPTION
```2022-02-09 18:55:43 ERROR    APIv2-Thread_2 :: [1405fbb] Missing time zone for network: Prime Video```