### PR TITLE
Add Missing time zone for network: Cartoon Network Everything, Slash, Red Bull TV

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -945,6 +945,7 @@ France 2:Europe/Paris
 France 3:Europe/Paris
 France 4:Europe/Paris
 France 5:Europe/Paris
+France TV Slash:Europe/Paris
 France Ô:Europe/Paris
 Fred TV:US/Eastern
 FreeForm:US/Eastern
@@ -1829,6 +1830,7 @@ Real Hip-Hop Network (US):US/Eastern
 Really:Europe/London
 Record TV (UK):Europe/London
 Record:America/Sao_Paulo
+Red Bull TV:US/Eastern
 Red Hot TV:Europe/London
 Rede Bandeirantes:America/Sao_Paulo
 Rede Globo:America/Sao_Paulo
@@ -2040,6 +2042,7 @@ Sky1:Europe/London
 Sky2:Europe/London
 Sky3:Europe/London
 SkyPerfecTV (JP):Asia/Tokyo
+Slash:Europe/Paris
 Sleuth (TV):US/Eastern
 Sleuth:US/Eastern
 Slice:Canada/Eastern
@@ -2745,6 +2748,7 @@ euronews (UK):Europe/London
 extra (AU):Australia/Sydney
 family MOVIES (AU):Australia/Sydney
 five:Europe/London
+france.tv slash:Europe/Paris
 france.tv:Europe/Paris
 fullscreen:US/Eastern
 funnyordie.com (US):US/Eastern

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -507,6 +507,7 @@ Carlton Television:Europe/London
 Cartoon Hangover:US/Pacific
 Cartoon Network (CA):Canada/Eastern
 Cartoon Network Australia:Australia/Sydney
+Cartoon Network Everything:US/Eastern
 Cartoon Network:US/Eastern
 Cartoonito:Europe/London
 Casa:Canada/Eastern


### PR DESCRIPTION
```2022-02-11 08:45:59 ERROR    SHOWQUEUE-ADD :: [1405fbb] Missing time zone for network: Cartoon Network Everything```  
fix https://github.com/pymedusa/Medusa/issues/10328  
fix https://github.com/pymedusa/Medusa/issues/10329  
