### PR TITLE
Add Missing time zone for network: Zweites Deutsches Fernsehen (ZDF)

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -2703,6 +2703,7 @@ Zee TV:Asia/Kolkata
 Zhejiang TV:Asia/Shanghai
 Zing (UK):Europe/London
 Ztélé:Canada/Eastern
+Zweites Deutsches Fernsehen (ZDF):Europe/Berlin
 [v] (AU):Australia/Sydney
 [v] HITS (AU):Australia/Sydney
 a-pac (AU):Australia/Sydney


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10375