### PR TITLE
Add Missing time zone for network: TV 2 (NO), Fox Showcase

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -942,6 +942,7 @@ Fox Life:Europe/Rome
 Fox Network:US/Eastern
 Fox Reality Channel:US/Eastern
 Fox Reality:US/Eastern
+Fox Showcase:Australia/Sydney
 Fox Soccer Channel (CA):Canada/Eastern
 Fox Sports 1:US/Eastern
 Fox8:Australia/Sydney
@@ -2243,6 +2244,7 @@ TUFF TV (US):US/Eastern
 TURNER CLASSIC MOVIES (AU):Australia/Sydney
 TURNER CLASSIC MOVIES (US):US/Eastern
 TV 2 (DK):Europe/Copenhagen
+TV 2 (NO):Europe/Oslo
 TV 2 Charlie:Europe/Copenhagen
 TV 2 Filmkanalen:Europe/Oslo
 TV 2 Fri:Europe/Copenhagen


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10444
fix https://github.com/pymedusa/Medusa/issues/10445