### PR TITLE
Add Reshet 13 (Channel 13) to network timezones

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -524,6 +524,7 @@ Ceskoslovenská televize:Europe/Prague
 Challenge:Europe/London
 Channel 10 (IL):Asia/Jerusalem
 Channel 101:US/Eastern
+Channel 13:Asia/Jerusalem
 Channel 2:Asia/Jerusalem
 Channel 3:Asia/Bangkok
 Channel 4 Television Corporation:Europe/London
@@ -1869,6 +1870,7 @@ RedeTV! (BR):America/Sao_Paulo
 ReelzChannel:US/Eastern
 Reformation Channel (US):US/Eastern
 Renault TV (UK):Europe/London
+Reshet 13:Asia/Jerusalem
 Retail TV (UK):Europe/London
 Rete 4:Europe/Rome
 Revelation TV:Europe/London


### PR DESCRIPTION
I have this for the show BlackSpace (https://www.tvmaze.com/shows/53152/blackspace). The channel used to be call Reshet 13 but is now just called Channel 13 (https://en.wikipedia.org/wiki/Channel_13_(Israel)). I added both in case some indexes (like tv maze: https://www.tvmaze.com/networks/1579/reshet-13) are still using the old name.

Fixes: https://github.com/pymedusa/Medusa/issues/10545