### PR TITLE
Add Amazon Freevee

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -97,6 +97,7 @@ AHC:US/Eastern
 AIT International (UK):Europe/London
 ALT Balaji:Asia/Kolkata
 AMAZING FACTS (US):US/Eastern
+Amazon Freevee:US/Eastern
 AMC Premiere:US/Eastern
 AMC+:US/Eastern
 AMC:US/Eastern


### PR DESCRIPTION
Adding Amazon Freevee (formerly known as imdbtv: https://en.wikipedia.org/wiki/Amazon_Freevee). The timezone says `global` in tvmaze (https://www.tvmaze.com/webchannels/251/amazon-freevee) so I just used US/Eastern as a seemingly good default since that's what a lot of other american streaming sites seem to use in this text file (eg: Netflix)

Fixes: https://github.com/pymedusa/Medusa/issues/10544