### PR TITLE
Add Missing time zone for network: Citytv

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -572,6 +572,7 @@ Cinemax:US/Eastern
 Citv (UK):Europe/London
 City Channel:Europe/Dublin
 City:Canada/Eastern
+Citytv:Canada/Eastern
 Classic Arts Showcase:US/Eastern
 Classic FM TV:Europe/London
 Club Illico:Canada/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10586
source: https://thetvdb.com/companies/city