### PR TITLE
Add Missing time zone for network: Warner TV

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -2671,6 +2671,7 @@ Warner Bros.:US/Eastern
 Warner Channel (AR):America/Buenos_Aires
 Warner Channel:US/Eastern
 Warner Home Video:US/Eastern
+Warner TV:Europe/Paris
 Watch ABC:US/Eastern
 Watch Disney Channel:US/Eastern
 Watch:Europe/London


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10665
source: https://thetvdb.com/companies/warner-tv