### PR TITLE
Add Missing time zone for network: Fox Kids Network, GameTV Canada

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -944,6 +944,7 @@ Fox Channel:Europe/Berlin
 Fox Crime:Europe/Rome
 Fox España:Europe/Madrid
 Fox Family:US/Eastern
+Fox Kids Network:US/Eastern
 Fox Kids:US/Eastern
 Fox Life (IT):Europe/Rome
 Fox Life (NL):Europe/Amsterdam
@@ -1007,6 +1008,7 @@ Galavisión (US):US/Eastern
 Gamavision (MX):America/Mexico_City
 Game Show Network (US):US/Eastern
 Game Show Network:US/Eastern
+GameTV Canada:Canada/Eastern
 GameTap Entertainment:US/Eastern
 Gay Network (UK):Europe/London
 GayXChange (UK):Europe/London


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10666
fix https://github.com/pymedusa/Medusa/issues/10667
source: https://thetvdb.com/companies/gametv-canada