### PR TITLE
Add Missing time zone for network: Discovery+ (UK)

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -718,6 +718,7 @@ Discovery home & health (AU):Australia/Sydney
 Discovery turbo MAX (AU):Australia/Sydney
 Discovery+ (NO):Europe/Oslo
 Discovery+ (SE):Europe/Stockholm
+Discovery+ (UK):Europe/London
 Discovery+:US/Eastern
 Discovery:US/Eastern
 Dish TV:US/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10683