### PR TITLE
Add Missing time zone for network: BBC Wales, TV 2 Play

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -2290,6 +2290,7 @@ TV 2 Charlie:Europe/Copenhagen
 TV 2 Filmkanalen:Europe/Oslo
 TV 2 Fri:Europe/Copenhagen
 TV 2 Nyhetskanalen:Europe/Oslo
+TV 2 Play:Europe/Oslo
 TV 2 Science Fiction:Europe/Oslo
 TV 2 Sport:Europe/Oslo
 TV 2 Sumo:Europe/Oslo

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -290,6 +290,7 @@ BBC TWO:Europe/London
 BBC Three:Europe/London
 BBC Two:Europe/London
 BBC UKTV (AU):Australia/Sydney
+BBC Wales:Europe/London
 BBC World News:Europe/London
 BBC iPlayer:Europe/London
 BBC one London:Europe/London


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10809  
fix https://github.com/pymedusa/Medusa/issues/10811