### PR TITLE
Add Missing time zone for network: Disney+ Hotstar

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -742,6 +742,7 @@ Disney Play:US/Eastern
 Disney Television Animation:US/Eastern
 Disney XD (CA):Canada/Eastern
 Disney XD:US/Eastern
+Disney+ Hotstar:Asia/Kolkata
 Disney+:US/Eastern
 Disney-ABC Domestic Television:US/Eastern
 DisneyLife:US/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/10814
source: https://thetvdb.com/companies/hotstar