### PR TITLE
Add Missing time zone for network: Canal+ Polska

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -518,6 +518,7 @@ Canal+ (ES):Europe/Madrid
 Canal+ (FR):Europe/Paris
 Canal+ Cyfrowy:Europe/Warsaw
 Canal+ Poland:Europe/Warsaw
+Canal+ Polska:Europe/Warsaw
 Canal+:Europe/Paris
 Canale 5:Europe/Rome
 Cancao News (US):US/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/11039