### PR TITLE
Add Missing time zone for network: Polsat Box Go, BBC Cymru Wales

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1780,6 +1780,7 @@ Playhouse Disney:US/Eastern
 Playstation:US/Eastern
 Playz:Europe/Madrid
 Plug RTL:Europe/Brussels
+Polsat Box Go:Europe/Warsaw
 Polsat:Europe/Warsaw
 Pop Girl (UK):Europe/London
 Pop:US/Eastern

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -257,6 +257,7 @@ BBC Alba:Europe/London
 BBC America:US/Eastern
 BBC Canada:Canada/Eastern
 BBC Channel 4:Europe/London
+BBC Cymru Wales:Europe/London
 BBC Drama Productions:Europe/London
 BBC FOUR:Europe/London
 BBC Films:Europe/London


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/11077  
fix https://github.com/pymedusa/Medusa/issues/11082