### PR TITLE
Add Missing time zone for network:  Prima+

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1801,6 +1801,7 @@ Press TV:Asia/Tehran
 Price Drop (UK):Europe/London
 Prima Family (CZ):Europe/Prague
 Prima televize:Europe/Prague
+Prima+:Europe/Prague
 Prima:Europe/Prague
 Prime (BE):Europe/Brussels
 Prime (NZ):Pacific/Auckland


### PR DESCRIPTION
Please add missing time zone for network Prima+.

Relevant error message from log:
`2023-04-15 12:43:03 ERROR    SHOWQUEUE-ADD :: [] Missing time zone for network: Prima+`