### PR TITLE
Add Missing time zone for network: DailyWire+ and Cartoon Network (Canada), Histoire TV, Game One

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -536,6 +536,7 @@ Caracol TV:America/Bogota
 Carlton Television:Europe/London
 Cartoon Hangover:US/Pacific
 Cartoon Network (CA):Canada/Eastern
+Cartoon Network (Canada):Canada/Eastern
 Cartoon Network Australia:Australia/Sydney
 Cartoon Network Everything:US/Eastern
 Cartoon Network Latin America:America/Mexico_City
@@ -681,6 +682,7 @@ DTD (AU):Australia/Sydney
 DTOUR (CA):Canada/Eastern
 DUSK (CA):Canada/Eastern
 DaAi TV:Asia/Taipei
+DailyWire+:US/Eastern
 Dailymotion:US/Eastern
 Dangerjane.tv (US):US/Eastern
 Danmarks Radio (DR):Europe/Copenhagen

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1054,6 +1054,7 @@ GagaOOLala:Asia/Taipei
 Gaiam TV:US/Eastern
 Galavisión (US):US/Eastern
 Gamavision (MX):America/Mexico_City
+Game One:Europe/Paris
 Game Show Network (US):US/Eastern
 Game Show Network:US/Eastern
 GameTV Canada:Canada/Eastern
@@ -1143,6 +1144,7 @@ HiT Entertainment:Europe/London
 Hidayat TV (UK):Europe/London
 High Street TV (UK):Europe/London
 Hikari TV:Asia/Tokyo
+Histoire TV:Europe/Paris
 Histoire:Europe/Paris
 Historia (CA):Canada/Eastern
 Historia (ES):Europe/Madrid


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/11530  
fix https://github.com/pymedusa/Medusa/issues/11541  
fix https://github.com/pymedusa/Medusa/issues/11539
