### PR TITLE
Add Missing time zone for network: Prime, NEON, UKTV Play, CTV Life C…

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1575,7 +1575,7 @@ NDTV India:Asia/Kolkata
 NECN (US):US/Eastern
 NECO:Asia/Tokyo
 NEN (AU):Australia/Sydney
-NEON:Pacific/Auckland
+NEON:US/Eastern
 NET 5:Europe/Amsterdam
 NET5 & VT4:Europe/Amsterdam
 NEW (AU):Australia/Sydney

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -492,6 +492,7 @@ CTV (TW):Asia/Taipei
 CTV Comedy Channel:Canada/Eastern
 CTV Comedy:Canada/Eastern
 CTV Drama (Bravo):Canada/Eastern
+CTV Life Channel:Canada/Eastern
 CTV News Channel (CA):Canada/Eastern
 CTV Sci-Fi (Space):Canada/Eastern
 CTV Sci-Fi Channel:Canada/Eastern
@@ -1574,6 +1575,7 @@ NDTV India:Asia/Kolkata
 NECN (US):US/Eastern
 NECO:Asia/Tokyo
 NEN (AU):Australia/Sydney
+NEON:Pacific/Auckland
 NET 5:Europe/Amsterdam
 NET5 & VT4:Europe/Amsterdam
 NEW (AU):Australia/Sydney
@@ -1863,6 +1865,7 @@ Prima:Europe/Prague
 Prime (BE):Europe/Brussels
 Prime (NZ):Pacific/Auckland
 Prime Video:US/Eastern
+Prime:Pacific/Auckland
 Primetime (UK):Europe/London
 ProSieben Fun:Europe/Berlin
 ProSieben MAXX:Europe/Berlin
@@ -2681,6 +2684,7 @@ UKTV Drama:Europe/London
 UKTV Food:Europe/London
 UKTV Gold:Europe/London
 UKTV History:Europe/London
+UKTV Play:Europe/London
 UKTV Style:Europe/London
 UKTV Yesterday:Europe/London
 UMP Movies (UK):Europe/London


### PR DESCRIPTION
…hannel

fix https://github.com/pymedusa/Medusa/issues/11651   
fix https://github.com/pymedusa/Medusa/issues/11650   
fix https://github.com/pymedusa/Medusa/issues/11647    
fix https://github.com/pymedusa/Medusa/issues/11646  

Not sure about Prime and NEON.
Prime is too generic a name, but there is only one channel here strictly with that name without the extra letters https://www.themoviedb.org/network/1567  

NEON:
There is only one channel in this database that is simply called NEON https://www.themoviedb.org/company/90733/movie. 
It's a US channel.

However, in the provided log you can see that the error is caused by Dark City: The Cleaner https://thetvdb.com/series/dark-city-the-cleaner.
According to this information it is broadcast on Neon TV https://thetvdb.com/companies/neon-tv.
Neon TV is a New Zealand channel.

I left the US channel as the name fits better.