### PR TITLE
Add Missing time zone for network: Collegehumor, ABS-CBN, iTunes Store

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -613,6 +613,7 @@ Club Illico:Canada/Eastern
 Club RTL:Europe/Brussels
 Club illico:Canada/Eastern
 Clubland (UK):Europe/London
+Collegehumor:US/Eastern
 Colorado's Own Channel 2 (US):US/Eastern
 Colors (UK):Europe/London
 Colors:Asia/Kolkata

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -91,6 +91,7 @@ ABP New (UK):Europe/London
 ABQ (AU):Australia/Sydney
 ABS (AU):Australia/Sydney
 ABS-CBN Broadcasting Company:Asia/Manila
+ABS-CBN:Asia/Manila
 ABT (AU):Australia/Sydney
 ABV (AU):Australia/Sydney
 ABW (AU):Australia/Sydney
@@ -3037,6 +3038,7 @@ iCHANNEL (CA):Canada/Eastern
 iQIYI:Asia/Shanghai
 iQiyi:Asia/Shanghai
 iTunes (US):US/Eastern
+iTunes Store:US/Eastern
 iTunes:US/Eastern
 iWantTFC:Asia/Manila
 id discovery:US/Eastern


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/11745
fix https://github.com/pymedusa/Medusa/issues/11748  
fix https://github.com/pymedusa/Medusa/issues/11749  