### PR TITLE
Add Missing time zone for network: Paramount+ with Showtime

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1823,6 +1823,7 @@ Pakistan Television Corporation (PK):Asia/Karachi
 Pantaya:US/Eastern
 Paramount Comedy:Europe/London
 Paramount Network:US/Eastern
+Paramount+ with Showtime:US/Eastern
 Paramount+:US/Eastern
 Paravi:Asia/Tokyo
 Paris Première (FR):Europe/Paris


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/11789