### PR TITLE
Add Missing time zone for network: U&GOLD, U&alibi, Canal+ Premium

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -541,6 +541,7 @@ Canal+ (FR):Europe/Paris
 Canal+ Cyfrowy:Europe/Warsaw
 Canal+ Poland:Europe/Warsaw
 Canal+ Polska:Europe/Warsaw
+Canal+ Premium:Europe/Warsaw
 Canal+:Europe/Paris
 Canale 5:Europe/Rome
 Cancao News (US):US/Eastern

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -2745,8 +2745,10 @@ Télé-Québec:Canada/Eastern
 Télétoon:Europe/Paris
 U&Alibi:Europe/London
 U&Dave:Europe/London
+U&GOLD:Europe/London
 U&W:Europe/London
 U&Yesterday:Europe/London
+U&alibi:Europe/London
 U+ Mobile TV:Asia/Seoul
 U:Pacific/Auckland
 UBC Channel 10 (TH):Asia/Bangkok


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/11896   
fix https://github.com/pymedusa/Medusa/issues/11897  
fix https://github.com/pymedusa/Medusa/issues/11898