### PR TITLE
Add timezone for Westdeutscher Rundfunk

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -2947,6 +2947,7 @@ WealthTV:US/Eastern
 Weather Network (CA):Canada/Eastern
 WeatherNation (US):US/Eastern
 West Digital Television (AU):Australia/Sydney
+Westdeutscher Rundfunk:Europe/Berlin
 Wink:Europe/Moscow
 Word Network (UK):Europe/London
 Worship (US):US/Eastern


### PR DESCRIPTION
Fixes this error (presumably):

```
2024-12-30 14:39:36 ERROR    MAIN :: [] Missing time zone for network: Westdeutscher Rundfunk
```

Not sure, why there are these duplicates:

https://www.thetvdb.com/companies/wdr
https://www.thetvdb.com/companies/westdeutscher-rundfunk-wdr

Anyway, the timezone is for the latter.