### PR TITLE
Add Missing time zone for network: HBO Romania, Hessischer Rundfunk, Funk

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1072,6 +1072,7 @@ Frost Great Outdoors (US):US/Eastern
 Fuel TV:US/Eastern
 Fuji TV:Asia/Tokyo
 Fullscreen:US/Eastern
+Funk:Europe/Berlin
 Funny or Die:US/Eastern
 Fuse:US/Eastern
 Fusion (US):US/Eastern
@@ -1160,6 +1161,7 @@ HBO Latin America:America/Sao_Paulo
 HBO Magyarország:Europe/Budapest
 HBO Max:US/Eastern
 HBO Nordic:Europe/Stockholm
+HBO Romania:Europe/Bucharest
 HBO Signature (US):US/Eastern
 HBO Česká Republika:Europe/Prague
 HBO2 (US):US/Eastern
@@ -1200,6 +1202,7 @@ Healthy Living Network (US):US/Eastern
 Heart TV (UK):Europe/London
 Heavenly:Asia/Seoul
 Here TV:US/Eastern
+Hessischer Rundfunk:Europe/Berlin
 Het Gesprek (NL):Europe/Amsterdam
 HiT Entertainment:Europe/London
 Hidayat TV (UK):Europe/London


### PR DESCRIPTION
Added timezones for:
- 2025-06-23 19:29:43 ERROR    MAIN :: [] Missing time zone for network: HBO Romania
- 2025-06-23 19:29:43 ERROR    MAIN :: [] Missing time zone for network: Hessischer Rundfunk
- 2025-06-23 19:29:43 ERROR    MAIN :: [] Missing time zone for network: Funk

fix https://github.com/pymedusa/Medusa/issues/12012
fix https://github.com/pymedusa/Medusa/issues/12013
fix https://github.com/pymedusa/Medusa/issues/12014