### PR TITLE
Add Missing time zone for network: HBO Brazil

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1157,6 +1157,7 @@ H2 (UK):Europe/London
 H2:US/Eastern
 HBO Asia:Asia/Singapore
 HBO Brasil:America/Sao_Paulo
+HBO Brazil:America/Sao_Paulo
 HBO CANADA:Canada/Eastern
 HBO Canada:Canada/Eastern
 HBO España:Europe/Madrid


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/12047