### PR TITLE
Add Missing time zone for network: London Weekend Television, CATCHPLAY+, APTN+

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -131,6 +131,7 @@ ANT1:Europe/Athens
 ANTENNA TV (US):US/Eastern
 AOL (US):US/Eastern
 AOL:US/Eastern
+APTN+:Canada/Eastern
 APTN:Canada/Eastern
 ARD:Europe/Berlin
 ARISE News (UK):Europe/London
@@ -442,6 +443,7 @@ CARS.TV (US):US/Eastern
 CARTOON NETWORK (AU):Australia/Sydney
 CARTOON NETWORK (UK):Europe/London
 CARTOON NETWORK TOO (UK):Europe/London
+CATCHPLAY+:Asia/Taipei
 CATHOLICTV (US):US/Eastern
 CBBC:Europe/London
 CBC (CA):Canada/Eastern

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1486,6 +1486,7 @@ Local 4 (US):US/Eastern
 Logo TV:US/Eastern
 Logo:US/Eastern
 London Weekend Television (LWT):Europe/London
+London Weekend Television:Europe/London
 Love Nature:Canada/Eastern
 Loveworld TV (UK):Europe/London
 Luxury TV (UK):Europe/London


### PR DESCRIPTION
fix https://github.com/pymedusa/Medusa/issues/12285  
fix https://github.com/pymedusa/Medusa/issues/12288  
fix https://github.com/pymedusa/Medusa/issues/12289